### PR TITLE
#57 - Refactors app to use FogosTheme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:fogosmobile/screens/about/about.dart';
 import 'package:fogosmobile/screens/partners.dart';
 import 'package:fogosmobile/screens/info_page.dart';
 import 'package:fogosmobile/screens/statistics_page.dart';
+import 'package:fogosmobile/styles/theme.dart';
 import 'package:redux/redux.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:fogosmobile/actions/fires_actions.dart';
@@ -39,6 +40,7 @@ class MyApp extends StatelessWidget {
       store: store, // store comes from the app_store.dart import
       child: MaterialApp(
         title: 'Fogos.pt',
+        theme: FogosTheme().themeData,
         debugShowCheckedModeBanner: false,
         routes: <String, WidgetBuilder>{
           '$SETTINGS_ROUTE': (_) => new Settings(),
@@ -48,7 +50,6 @@ class MyApp extends StatelessWidget {
           '$INFO_ROUTE': (_) => new InfoPage(),
           '$ABOUT_ROUTE': (_) => new About(),
           '$FIRE_DETAILS_ROUTE': (_) => new FireDetailsPage(),
-
         },
         home: FirstPage(),
         localizationsDelegates: [
@@ -82,32 +83,26 @@ class _FirstPageState extends State<FirstPage> with WidgetsBindingObserver {
   }
 
   void iOSPermission() {
-    _firebaseMessaging.requestNotificationPermissions(
-        IosNotificationSettings(sound: true, badge: true, alert: true));
-    _firebaseMessaging.onIosSettingsRegistered
-        .listen((IosNotificationSettings settings) {});
+    _firebaseMessaging.requestNotificationPermissions(IosNotificationSettings(sound: true, badge: true, alert: true));
+    _firebaseMessaging.onIosSettingsRegistered.listen((IosNotificationSettings settings) {});
   }
 
+  Widget _buildRefreshButton(AppState state, VoidCallback action) => state.isLoading
+      ? Container(
+          width: 54.0,
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: new CircularProgressIndicator(
+              strokeWidth: 2.0,
+            ),
+          ),
+        )
+      : new IconButton(
+          onPressed: action,
+          icon: new Icon(Icons.refresh),
+        );
 
-  Widget _buildRefreshButton(AppState state, VoidCallback action) =>
-      state.isLoading
-          ? Container(
-              width: 54.0,
-              child: Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: new CircularProgressIndicator(
-                  strokeWidth: 2.0,
-                ),
-              ),
-            )
-          : new IconButton(
-              onPressed: action,
-              icon: new Icon(Icons.refresh),
-            );
-
-  Widget _buildFiltersMenu(AppState state) =>
-      StoreConnector<AppState, SetFiltersCallback>(
-          converter: (Store<AppState> store) {
+  Widget _buildFiltersMenu(AppState state) => StoreConnector<AppState, SetFiltersCallback>(converter: (Store<AppState> store) {
         return (FireStatus filter) {
           store.dispatch(SelectFireFiltersAction(filter));
         };
@@ -118,16 +113,18 @@ class _FirstPageState extends State<FirstPage> with WidgetsBindingObserver {
           itemBuilder: (BuildContext context) => FireStatus.values
               .map((status) => PopupMenuItem<FireStatus>(
                   value: status,
-                  child: ListTile(
-                      dense: true,
-                      contentPadding: const EdgeInsets.all(0.0),
-                      selected: state.activeFilters.contains(status),
-                      trailing: state.activeFilters.contains(status)
-                          ? Icon(Icons.check)
-                          : null,
-                      title: Text(
-                        FogosLocalizations.of(context).textFireStatus(status),
-                      ))))
+                  child: ListTileTheme(
+                    style: ListTileStyle.drawer,
+                    selectedColor: Theme.of(context).accentColor,
+                    child: ListTile(
+                        dense: true,
+                        contentPadding: const EdgeInsets.all(0.0),
+                        selected: state.activeFilters.contains(status),
+                        trailing: state.activeFilters.contains(status) ? Icon(Icons.check) : null,
+                        title: Text(
+                          FogosLocalizations.of(context).textFireStatus(status),
+                        )),
+                  )))
               .toList(),
         );
       });
@@ -156,16 +153,13 @@ class _FirstPageState extends State<FirstPage> with WidgetsBindingObserver {
   Widget build(BuildContext context) {
     firebaseCloudMessagingListeners();
 
-    SystemChrome.setApplicationSwitcherDescription(
-        ApplicationSwitcherDescription(
-            label: "Fogos.pt", primaryColor: Colors.black.value));
+    SystemChrome.setApplicationSwitcherDescription(ApplicationSwitcherDescription(label: "Fogos.pt", primaryColor: Colors.black.value));
 
     return new StoreConnector<AppState, AppState>(
       converter: (Store<AppState> store) => store.state,
       builder: (BuildContext context, AppState state) {
         return Scaffold(
           appBar: new FireGradientAppBar(
-            iconTheme: new IconThemeData(color: Colors.white),
             title: new Text(
               'Fogos.pt',
               style: new TextStyle(color: Colors.white),
@@ -188,10 +182,8 @@ class _FirstPageState extends State<FirstPage> with WidgetsBindingObserver {
                   return new StoreConnector<AppState, AppState>(
                     converter: (Store<AppState> store) => store.state,
                     builder: (BuildContext context, AppState state) {
-                      if ((state.hasFirstLoad == false ||
-                              state.hasFirstLoad == null) &&
-                          (state.isLoading == false ||
-                              state.isLoading == null) &&
+                      if ((state.hasFirstLoad == false || state.hasFirstLoad == null) &&
+                          (state.isLoading == false || state.isLoading == null) &&
                           state.fires.length == 0) {
                         loadFiresAction();
                       }
@@ -211,8 +203,7 @@ class _FirstPageState extends State<FirstPage> with WidgetsBindingObserver {
               children: <Widget>[
                 new DrawerHeader(
                   child: new Center(
-                    child: SvgPicture.asset(imgSvgLogoFlame,
-                        color: Colors.redAccent),
+                    child: SvgPicture.asset(imgSvgLogoFlame, color: Colors.redAccent),
                   ),
                   decoration: new BoxDecoration(
                     color: Color(0xff883333),

--- a/lib/screens/about/about.dart
+++ b/lib/screens/about/about.dart
@@ -25,8 +25,7 @@ class About extends StatelessWidget {
                     return Scrollbar(
                         child: ListView.builder(
                       padding: EdgeInsets.only(top: 8.0),
-                      itemBuilder: (_, int i) =>
-                          ContributorItem(contributor: contributors[i]),
+                      itemBuilder: (_, int i) => ContributorItem(contributor: contributors[i]),
                       itemCount: contributors.length,
                     ));
                   }
@@ -43,7 +42,6 @@ class About extends StatelessWidget {
   Widget build(BuildContext context) {
     return new Scaffold(
         appBar: new FireGradientAppBar(
-          iconTheme: new IconThemeData(color: Colors.white),
           title: new Text(
             'Sobre',
             style: new TextStyle(color: Colors.white),
@@ -70,8 +68,7 @@ class About extends StatelessWidget {
                         new TextSpan(
                           text: FogosLocalizations.of(context).textCivilProtection,
                           style: new TextStyle(color: Colors.blue),
-                          recognizer: new TapGestureRecognizer()
-                            ..onTap = () => launchURL('http://www.prociv.pt/'),
+                          recognizer: new TapGestureRecognizer()..onTap = () => launchURL('http://www.prociv.pt/'),
                         ),
                       ],
                     ),
@@ -97,8 +94,7 @@ class About extends StatelessWidget {
                         new TextSpan(
                           text: 'mail@fogos.pt.',
                           style: new TextStyle(color: Colors.blue),
-                          recognizer: new TapGestureRecognizer()
-                            ..onTap = () => launchURL('mailto:mail@fogos.pt'),
+                          recognizer: new TapGestureRecognizer()..onTap = () => launchURL('mailto:mail@fogos.pt'),
                         ),
                       ],
                     ),

--- a/lib/screens/components/fire_gradient_app_bar.dart
+++ b/lib/screens/components/fire_gradient_app_bar.dart
@@ -3,13 +3,8 @@ import 'package:flutter_redux/flutter_redux.dart';
 import 'package:fogosmobile/models/app_state.dart';
 
 class FireGradientAppBar extends AppBar {
-  FireGradientAppBar(
-      {IconThemeData iconTheme,
-      Text title,
-      List<StoreConnector<AppState, VoidCallback>> actions,
-      TabBar bottom})
+  FireGradientAppBar({Text title, List<StoreConnector<AppState, VoidCallback>> actions, TabBar bottom})
       : super(
-          iconTheme: iconTheme,
           title: title,
           backgroundColor: Colors.white,
           elevation: 0.5,

--- a/lib/screens/fire_details.dart
+++ b/lib/screens/fire_details.dart
@@ -38,7 +38,6 @@ class FireDetailsPage extends StatelessWidget {
             }
             return Scaffold(
               appBar: FireGradientAppBar(
-                iconTheme: IconThemeData(color: Colors.white),
                 title: Text(
                   _title,
                   style: TextStyle(color: Colors.white),

--- a/lib/screens/info_page.dart
+++ b/lib/screens/info_page.dart
@@ -47,7 +47,6 @@ class InfoPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: new FireGradientAppBar(
-        iconTheme: new IconThemeData(color: Colors.white),
         title: new Text(
           FogosLocalizations.of(context).textInformations,
           style: new TextStyle(color: Colors.white),
@@ -60,10 +59,7 @@ class InfoPage extends StatelessWidget {
             title: Text(FogosLocalizations.of(context).textInformationIncidentStatus.toUpperCase(), style: _header),
             contentPadding: EdgeInsets.symmetric(horizontal: 0),
           ),
-          _occurencyBulletPoint(
-              FogosLocalizations.of(context).textInformationFirstOrderDispatch,
-              imgSvgIconAlarm,
-              Color(0xffff6e02)),
+          _occurencyBulletPoint(FogosLocalizations.of(context).textInformationFirstOrderDispatch, imgSvgIconAlarm, Color(0xffff6e02)),
           _occurencyBulletPoint(
             FogosLocalizations.of(context).textInformationArrival,
             imgSvgIconPointer,
@@ -107,8 +103,7 @@ class InfoPage extends StatelessWidget {
           SizedBox(height: 20),
           MarkdownBody(
             data: _infoMarkdownData,
-            styleSheet:
-                MarkdownStyleSheet.fromTheme(Theme.of(context)).copyWith(
+            styleSheet: MarkdownStyleSheet.fromTheme(Theme.of(context)).copyWith(
               h1: _header,
               p: _body,
             ),

--- a/lib/screens/partners.dart
+++ b/lib/screens/partners.dart
@@ -8,7 +8,6 @@ class Partners extends StatelessWidget {
   Widget build(BuildContext context) {
     return new Scaffold(
         appBar: FireGradientAppBar(
-          iconTheme: new IconThemeData(color: Colors.white),
           title: new Text(
             FogosLocalizations.of(context).textPartners,
             style: new TextStyle(color: Colors.white),

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -51,7 +51,6 @@ class _SettingsState extends State<Settings> {
 
       return new Scaffold(
         appBar: new FireGradientAppBar(
-          iconTheme: new IconThemeData(color: Colors.white),
           title: new Text(
             FogosLocalizations.of(context).appTitle,
             style: new TextStyle(color: Colors.white),
@@ -67,7 +66,6 @@ class _SettingsState extends State<Settings> {
 
     return new Scaffold(
       appBar: new FireGradientAppBar(
-        iconTheme: new IconThemeData(color: Colors.white),
         title: new Text(
           FogosLocalizations.of(context).appTitle,
           style: new TextStyle(color: Colors.white),
@@ -91,8 +89,7 @@ class _SettingsState extends State<Settings> {
                 store.dispatch(new SetPreferenceAction(key, value));
               };
             },
-            builder: (BuildContext context,
-                SetPreferenceCallBack setPreferenceAction) {
+            builder: (BuildContext context, SetPreferenceCallBack setPreferenceAction) {
               return new Column(
                 children: <Widget>[
                   new Padding(
@@ -100,8 +97,7 @@ class _SettingsState extends State<Settings> {
                   ),
                   new ListTile(
                     title: new TextField(
-                      decoration: new InputDecoration(
-                          labelText: FogosLocalizations.of(context).textCounty),
+                      decoration: new InputDecoration(labelText: FogosLocalizations.of(context).textCounty),
                       controller: controller,
                     ),
                   ),
@@ -110,19 +106,12 @@ class _SettingsState extends State<Settings> {
                       itemCount: this.locations.length,
                       itemBuilder: (BuildContext context, int index) {
                         final _location = this.locations[index];
-                        return filter == null ||
-                                filter == "" ||
-                                _location['value']['name']
-                                    .toLowerCase()
-                                    .contains(filter.toLowerCase())
+                        return filter == null || filter == "" || _location['value']['name'].toLowerCase().contains(filter.toLowerCase())
                             ? CheckboxListTile(
                                 title: Text(_location['value']['name']),
-                                value: state.preferences[
-                                        'pref-${_location['key']}'] ==
-                                    1,
+                                value: state.preferences['pref-${_location['key']}'] == 1,
                                 onChanged: (bool value) {
-                                  setPreferenceAction(
-                                      _location['key'], value == true ? 1 : 0);
+                                  setPreferenceAction(_location['key'], value == true ? 1 : 0);
                                 },
                               )
                             : new Container();

--- a/lib/screens/settings/settings.dart
+++ b/lib/screens/settings/settings.dart
@@ -17,7 +17,6 @@ class _SettingsState extends State<Settings> {
       length: 3,
       child: Scaffold(
         appBar: new FireGradientAppBar(
-          iconTheme: new IconThemeData(color: Colors.white),
           title: new Text(
             FogosLocalizations.of(context).textNotifications,
             style: new TextStyle(color: Colors.white),
@@ -31,11 +30,7 @@ class _SettingsState extends State<Settings> {
           ),
         ),
         body: TabBarView(
-          children: [
-            Notifications(),
-            FireNotifications(),
-            OtherNotifications()
-          ],
+          children: [Notifications(), FireNotifications(), OtherNotifications()],
         ),
       ),
     );

--- a/lib/screens/statistics_page.dart
+++ b/lib/screens/statistics_page.dart
@@ -28,7 +28,6 @@ class _StatisticsPageState extends State<StatisticsPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: new FireGradientAppBar(
-        iconTheme: new IconThemeData(color: Colors.white),
         title: new Text(
           FogosLocalizations.of(context).textStatistics,
           style: new TextStyle(color: Colors.white),

--- a/lib/screens/warnings.dart
+++ b/lib/screens/warnings.dart
@@ -42,7 +42,6 @@ class _WarningsState extends State<Warnings> {
   Widget build(BuildContext context) {
     return new Scaffold(
       appBar: FireGradientAppBar(
-        iconTheme: new IconThemeData(color: Colors.white),
         title: new Text(
           FogosLocalizations.of(context).textWarnings,
           style: new TextStyle(color: Colors.white),
@@ -98,8 +97,7 @@ class _WarningsState extends State<Warnings> {
                         ),
                         Container(
                           child: RaisedButton(
-                            child: Text(FogosLocalizations.of(context)
-                                .textRefreshButton),
+                            child: Text(FogosLocalizations.of(context).textRefreshButton),
                             onPressed: this.getWarnigs,
                           ),
                         )

--- a/lib/styles/theme.dart
+++ b/lib/styles/theme.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 
 class FogosTheme {
-  static Color _primaryColor = Color(0xff512f);
-  static Color _accentColor = Color(0xf09819);
+  static Color _primaryColor = Color(0xffff512f);
+  static Color _accentColor = Color(0xfff09819);
 
   Color get primaryColor => _primaryColor;
   Color get accentColor => _accentColor;
@@ -10,6 +10,8 @@ class FogosTheme {
 
   static final ThemeData _themeData = ThemeData(
       brightness: Brightness.light,
+      iconTheme: IconThemeData(color: Colors.white),
+      indicatorColor: Colors.white,
       primaryColor: _primaryColor,
       primaryColorBrightness: Brightness.dark,
       accentColor: _accentColor,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.0"
   auto_size_text:
     dependency: "direct main"
     description:
@@ -505,7 +505,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.2"
   redux:
     dependency: "direct main"
     description:
@@ -615,7 +615,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.5"
+    version: "0.2.4"
   timing:
     dependency: transitive
     description:


### PR DESCRIPTION
This PR will:
* Adds `FogosTheme` to the `MaterialApp`.
___
### Note
**From now on, all styling should use theme whenever possible.** 

As a side note, the theme had the brightness set to `Brightness.dark`, but since it wasn't being used, probably no one had before noticed what actually becomes dark (such as Fire details background when loading and keyboard). IMO it doesn't look bad.

Anyway, I will leave up to the reviewer(s) to decide.