### PR TITLE
Use a gradient for drawer header.

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -272,10 +272,18 @@ class _FirstPageState extends State<FirstPage> with WidgetsBindingObserver {
               children: <Widget>[
                 new DrawerHeader(
                   child: new Center(
-                    child: SvgPicture.asset(imgSvgLogoFlame, color: Colors.redAccent),
+                    child: SvgPicture.asset(imgSvgLogoFlame, color: Colors.white),
                   ),
                   decoration: new BoxDecoration(
-                    color: Color(0xff883333),
+                    gradient: new LinearGradient(
+                        colors: [
+                          FogosTheme().accentColor,
+                          FogosTheme().primaryColor,
+                        ],
+                        begin: const FractionalOffset(0.0, 0.0),
+                        end: const FractionalOffset(1.0, 0.0),
+                        stops: [0.0, 1.0],
+                        tileMode: TileMode.clamp),
                   ),
                 ),
                 new ListTile(

--- a/lib/screens/components/fire_gradient_app_bar.dart
+++ b/lib/screens/components/fire_gradient_app_bar.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:fogosmobile/styles/theme.dart';
 
 class FireGradientAppBar extends AppBar {
   FireGradientAppBar({Text title, List<Widget> actions, TabBar bottom})
@@ -12,8 +13,8 @@ class FireGradientAppBar extends AppBar {
             decoration: new BoxDecoration(
               gradient: new LinearGradient(
                   colors: [
-                    Colors.orange,
-                    Colors.red,
+                    FogosTheme().accentColor,
+                    FogosTheme().primaryColor,
                   ],
                   begin: const FractionalOffset(0.0, 0.0),
                   end: const FractionalOffset(1.0, 0.0),


### PR DESCRIPTION
closes #69 
Uses same gradient as the appBar on the drawer header, for a consistent UI.
