### PR TITLE
#83 - Refactor to use Dio instead of HTTP

### DIFF
--- a/lib/middleware/contributors_middleware.dart
+++ b/lib/middleware/contributors_middleware.dart
@@ -1,7 +1,7 @@
 import 'package:fogosmobile/actions/contributors_actions.dart';
 import 'package:fogosmobile/models/contributor.dart';
+import 'package:fogosmobile/utils/network_utils.dart';
 import 'package:redux/redux.dart';
-import 'package:http/http.dart' as http;
 import 'dart:convert';
 import 'package:fogosmobile/models/app_state.dart';
 import 'package:fogosmobile/constants/endpoints.dart';
@@ -21,8 +21,8 @@ Middleware<AppState> _createLoadContributors() {
 
     try {
       String url = Endpoints.getMobileContributors;
-      final response = await http.get(url);
-      final responseData = json.decode(response.body);
+      final response = await get(url);
+      final responseData = json.decode(response.data);
       List<Contributor> contributors = Contributor.fromList(responseData);
       print("load contributors");
       store.dispatch(new ContributorsLoadedAction(contributors));

--- a/lib/middleware/fires_middleware.dart
+++ b/lib/middleware/fires_middleware.dart
@@ -1,6 +1,7 @@
 import 'package:fogosmobile/middleware/shared_preferences_manager.dart';
 import 'package:fogosmobile/models/fire_details.dart';
 import 'package:fogosmobile/utils/model_utils.dart';
+import 'package:fogosmobile/utils/network_utils.dart';
 import 'package:redux/redux.dart';
 import 'package:dio/dio.dart';
 import 'dart:convert';
@@ -36,7 +37,7 @@ Middleware<AppState> _createLoadFires() {
 
     try {
       String url = Endpoints.getFires;
-      Response response = await Dio().get(url);
+      final response = await get(url);
       final responseData = json.decode(response.data)["data"];
       List<Fire> fires = responseData.map<Fire>((model) => Fire.fromJson(model)).toList();
       fires = calculateFireImportance(fires);
@@ -64,7 +65,7 @@ Middleware<AppState> _createLoadFire() {
     String url = '${Endpoints.getFire}${action.fireId}';
 
     try {
-      Response response = await Dio().get(url);
+      final response = await get(url);
       final responseData = json.decode(response.data)["data"];
       if (responseData == null) {
         throw new StateError('No fire data could be loaded: $url');
@@ -95,7 +96,7 @@ Middleware<AppState> _createLoadFireMeansHistory() {
     String url = '${Endpoints.getFireMeansHistory}${action.fireId}';
 
     try {
-      Response response = await Dio().get(url);
+      final response = await get(url);
       final responseData = json.decode(response.data)["data"];
       if (responseData == null) {
         throw new StateError('No getFireMeansHistory could be loaded: $url');
@@ -126,7 +127,7 @@ Middleware<AppState> _createLoadFireDetailsHistory() {
     String url = '${Endpoints.getFireDetailsHistory}${action.fireId}';
 
     try {
-      Response response = await Dio().get(url);
+      final response = await get(url);
       final responseData = json.decode(response.data)["data"];
       if (responseData == null) {
         throw new StateError('No getFireDetailsHistory could be loaded: $url');
@@ -154,11 +155,11 @@ Middleware<AppState> _createLoadFireDetailsHistory() {
 Middleware<AppState> _createLoadFireRisk() {
   return (Store store, action, NextDispatcher next) async {
     next(action);
-    
+
     String url = '${Endpoints.getFireRisk}${action.fireId}';
 
     try {
-      Response response = await Dio().get(url);
+      final response = await get(url);
       final responseData = json.decode(response.data)["data"][0]['hoje'];
 
       if (responseData == null) {

--- a/lib/middleware/preferences_middleware.dart
+++ b/lib/middleware/preferences_middleware.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
 
 import 'package:fogosmobile/middleware/shared_preferences_manager.dart';
+import 'package:fogosmobile/utils/network_utils.dart';
 import 'package:redux/redux.dart';
-import 'package:http/http.dart' as http;
 import 'dart:convert';
 import 'package:firebase_messaging/firebase_messaging.dart';
 
@@ -29,8 +29,8 @@ Middleware<AppState> _createLoadPreferences() {
 
     try {
       String url = Endpoints.getLocations;
-      final response = await http.get(url);
-      final locations = json.decode(utf8.decode(response.bodyBytes))['rows'];
+      final response = await get(url);
+      final locations = response.data['rows'];
 
       Map data = {};
       final prefs = SharedPreferencesManager.preferences;

--- a/lib/middleware/statistics_middleware.dart
+++ b/lib/middleware/statistics_middleware.dart
@@ -1,7 +1,7 @@
 import 'package:fogosmobile/actions/statistics_actions.dart';
 import 'package:fogosmobile/models/statistics.dart';
+import 'package:fogosmobile/utils/network_utils.dart';
 import 'package:redux/redux.dart';
-import 'package:http/http.dart' as http;
 import 'dart:convert';
 import 'package:fogosmobile/models/app_state.dart';
 import 'package:fogosmobile/constants/endpoints.dart';
@@ -30,8 +30,8 @@ Middleware<AppState> _createLoadNowStats() {
     next(action);
     try {
       String url = Endpoints.getNowStats;
-      final response = await http.get(url);
-      final responseData = json.decode(response.body)['data'];
+      final response = await get(url);
+      final responseData = json.decode(response.data)['data'];
       NowStats nowStats = NowStats.fromJson(responseData);
       store.dispatch(new NowStatsLoadedAction(nowStats));
     } catch (e) {
@@ -48,8 +48,8 @@ Middleware<AppState> _createTodayStats() {
     next(action);
     try {
       String url = Endpoints.getTodayStats;
-      final response = await http.get(url);
-      final responseData = json.decode(response.body)['data'];
+      final response = await get(url);
+      final responseData = json.decode(response.data)['data'];
       TodayStats todayStats = TodayStats.fromJson(responseData);
       store.dispatch(new TodayStatsLoadedAction(todayStats));
     } catch (e) {
@@ -66,8 +66,8 @@ Middleware<AppState> _createYesterdayStats() {
     next(action);
     try {
       String url = Endpoints.getYesterdayStats;
-      final response = await http.get(url);
-      final responseData = json.decode(response.body)['data'];
+      final response = await get(url);
+      final responseData = json.decode(response.data)['data'];
       YesterdayStats yesterdayStats = YesterdayStats.fromJson(responseData);
       store.dispatch(new YesterdayStatsLoadedAction(yesterdayStats));
     } catch (e) {
@@ -84,8 +84,8 @@ Middleware<AppState> _createLastNightStats() {
     next(action);
     try {
       String url = Endpoints.getLastNightStats;
-      final response = await http.get(url);
-      final responseData = json.decode(response.body)['data'];
+      final response = await get(url);
+      final responseData = json.decode(response.data)['data'];
       LastNightStats lastNightStats = LastNightStats.fromJson(responseData);
       store.dispatch(new LastNightStatsLoadedAction(lastNightStats));
     } catch (e) {
@@ -102,8 +102,8 @@ Middleware<AppState> _createWeekStats() {
     next(action);
     try {
       String url = Endpoints.getWeekStats;
-      final response = await http.get(url);
-      final responseData = json.decode(response.body)['data'];
+      final response = await get(url);
+      final responseData = json.decode(response.data)['data'];
       WeekStats weekStats = WeekStats.fromJson(responseData);
       store.dispatch(new WeekStatsLoadedAction(weekStats));
     } catch (e) {
@@ -120,8 +120,8 @@ Middleware<AppState> _createLastHoursStats() {
     next(action);
     try {
       String url = Endpoints.getLastHoursStats;
-      final response = await http.get(url);
-      final responseData = json.decode(response.body)['data'];
+      final response = await get(url);
+      final responseData = json.decode(response.data)['data'];
       LastHoursStats lastHoursStats = LastHoursStats.fromJson(responseData);
       store.dispatch(new LastHoursLoadedAction(lastHoursStats));
     } catch (e) {

--- a/lib/middleware/warnings_middleware.dart
+++ b/lib/middleware/warnings_middleware.dart
@@ -1,5 +1,5 @@
+import 'package:fogosmobile/utils/network_utils.dart';
 import 'package:redux/redux.dart';
-import 'package:http/http.dart' as http;
 import 'dart:convert';
 
 import 'package:fogosmobile/models/warning.dart';
@@ -24,10 +24,9 @@ Middleware<AppState> _createLoadWarnings() {
 
     try {
       String url = Endpoints.getWarnings;
-      final response = await http.get(url);
-      final responseData = json.decode(response.body)['data'];
-      List<Warning> warnings =
-      responseData.map<Warning>((model) => Warning.fromJson(model)).toList();
+      final response = await get(url);
+      final responseData = json.decode(response.data)['data'];
+      List<Warning> warnings = responseData.map<Warning>((model) => Warning.fromJson(model)).toList();
       store.dispatch(new WarningsLoadedAction(warnings));
     } catch (e) {
       store.dispatch(new WarningsLoadedAction(null));
@@ -43,10 +42,9 @@ Middleware<AppState> _createLoadWarningsMadeira() {
 
     try {
       String url = Endpoints.getWarningsMadeira;
-      final response = await http.get(url);
-      final responseData = json.decode(response.body)['data'];
-      List<WarningMadeira> warnings =
-        responseData.map<WarningMadeira>((model) => WarningMadeira.fromJson(model)).toList();
+      final response = await get(url);
+      final responseData = json.decode(response.data)['data'];
+      List<WarningMadeira> warnings = responseData.map<WarningMadeira>((model) => WarningMadeira.fromJson(model)).toList();
       store.dispatch(new WarningsMadeiraLoadedAction(warnings));
     } catch (e) {
       store.dispatch(new WarningsMadeiraLoadedAction(null));

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -1,9 +1,7 @@
-import 'dart:convert';
-import 'dart:convert' show utf8;
 import 'package:fogosmobile/localization/fogos_localizations.dart';
-import 'package:http/http.dart' as http;
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
+import 'package:fogosmobile/utils/network_utils.dart';
 import 'package:redux/redux.dart';
 import 'package:fogosmobile/constants/endpoints.dart';
 import 'package:fogosmobile/models/app_state.dart';
@@ -35,9 +33,8 @@ class _SettingsState extends State<Settings> {
 
   getLocations() async {
     String url = Endpoints.getLocations;
-    final response = await http.get(url);
-    final data = json.decode(utf8.decode(response.bodyBytes));
-    return data['rows'];
+    final response = await get(url);
+    return response.data['rows'];
   }
 
   @override

--- a/lib/screens/settings/notifications.dart
+++ b/lib/screens/settings/notifications.dart
@@ -1,10 +1,8 @@
-import 'dart:convert';
-import 'dart:convert' show utf8;
 import 'package:fogosmobile/localization/fogos_localizations.dart';
 import 'package:fogosmobile/screens/utils/text_utils.dart';
-import 'package:http/http.dart' as http;
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
+import 'package:fogosmobile/utils/network_utils.dart';
 import 'package:redux/redux.dart';
 import 'package:fogosmobile/constants/endpoints.dart';
 import 'package:fogosmobile/models/app_state.dart';
@@ -34,9 +32,8 @@ class _NotificationsState extends State<Notifications> {
 
   getLocations() async {
     String url = Endpoints.getLocations;
-    final response = await http.get(url);
-    final data = json.decode(utf8.decode(response.bodyBytes));
-    return data['rows'];
+    final response = await get(url);
+    return response.data['rows'];
   }
 
   @override

--- a/lib/utils/network_utils.dart
+++ b/lib/utils/network_utils.dart
@@ -1,0 +1,16 @@
+import 'package:dio/dio.dart';
+
+final Dio _dio = Dio()
+  ..options.connectTimeout = 10000
+  ..options.receiveTimeout = 10000;
+
+Future<Response> get(String path) async {
+  try {
+    final Response response = await _dio.get(path);
+    print('Resquest to $path performed with success (${response?.statusCode}).');
+    return response;
+  } on DioError catch (e) {
+    print('Request to [$path] failed with error $e and headers [${e?.response?.headers}].');
+    return e?.response;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,10 +17,10 @@ dependencies:
   redux: ^3.0.0
   flutter_redux: ^0.5.2
   redux_logging: ^0.3.0
-  flutter_map: ^0.6.1+2
+  flutter_map: ^0.5.0
   http: ^0.12.0
   dio: ^2.1.7
-  firebase_messaging: ^5.0.4
+  firebase_messaging: ^2.1.0
   shared_preferences: ^0.4.3
   diacritic: ^0.1.1
   url_launcher: ^5.0.2
@@ -30,7 +30,7 @@ dependencies:
   share: ^0.6.1+1
 
   #ui
-  flutter_svg: ^0.13.0+2
+  flutter_svg: ^0.12.4
   modal_progress_hud: ^0.1.3
   charts_flutter: ^0.6.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,10 +17,10 @@ dependencies:
   redux: ^3.0.0
   flutter_redux: ^0.5.2
   redux_logging: ^0.3.0
-  flutter_map: ^0.5.0
+  flutter_map: ^0.6.1+2
   http: ^0.12.0
   dio: ^2.1.7
-  firebase_messaging: ^2.1.0
+  firebase_messaging: ^5.0.4
   shared_preferences: ^0.4.3
   diacritic: ^0.1.1
   url_launcher: ^5.0.2
@@ -30,7 +30,7 @@ dependencies:
   share: ^0.6.1+1
 
   #ui
-  flutter_svg: ^0.12.4
+  flutter_svg: ^0.13.0+2
   modal_progress_hud: ^0.1.3
   charts_flutter: ^0.6.0
 


### PR DESCRIPTION
## This PR will
- Refactor to use DIO instead of `http` by providing an utils method that use the same DIO instance to perform the requests;
- Update the `flutter_map`, `firebase_messaging` and `flutter_svg` to the latest versions in order to fix the build due to a Flutter SDK change.