### PR TITLE
Formats time on the means statistics graphs

### DIFF
--- a/lib/screens/components/meansStatistics.dart
+++ b/lib/screens/components/meansStatistics.dart
@@ -78,6 +78,12 @@ class MeansStatistics extends StatelessWidget {
                 child: charts.TimeSeriesChart(
                   _createSampleData(),
                   animate: true,
+                  domainAxis: new charts.DateTimeAxisSpec(
+                    tickFormatterSpec: charts.AutoDateTimeTickFormatterSpec(
+                      minute: new charts.TimeFormatterSpec(
+                          format: "Hm", transitionFormat: "Hm"),
+                    ),
+                  ),
                   behaviors: [
                     charts.SeriesLegend(
                       position: charts.BehaviorPosition.bottom,

--- a/lib/screens/components/meansStatistics.dart
+++ b/lib/screens/components/meansStatistics.dart
@@ -78,7 +78,7 @@ class MeansStatistics extends StatelessWidget {
                 child: charts.TimeSeriesChart(
                   _createSampleData(),
                   animate: true,
-                  domainAxis: new charts.DateTimeAxisSpec(
+                  domainAxis: charts.DateTimeAxisSpec(
                     tickFormatterSpec: charts.AutoDateTimeTickFormatterSpec(
                       minute: new charts.TimeFormatterSpec(
                           format: "Hm", transitionFormat: "Hm"),

--- a/lib/screens/components/meansStatistics.dart
+++ b/lib/screens/components/meansStatistics.dart
@@ -80,7 +80,7 @@ class MeansStatistics extends StatelessWidget {
                   animate: true,
                   domainAxis: charts.DateTimeAxisSpec(
                     tickFormatterSpec: charts.AutoDateTimeTickFormatterSpec(
-                      minute: new charts.TimeFormatterSpec(
+                      minute: charts.TimeFormatterSpec(
                           format: "Hm", transitionFormat: "Hm"),
                     ),
                   ),


### PR DESCRIPTION
Time along the x axis is now formatted as "07:45  08:00  08:15  08:30" instead of "7 45  8 00  15  30"

Fixes https://github.com/FogosPT/fogosmobile/issues/113